### PR TITLE
Refactor LabelModel, MTLabelModel, and TaskGraph

### DIFF
--- a/metal/multitask/__init__.py
+++ b/metal/multitask/__init__.py
@@ -1,4 +1,4 @@
-from .task_graph import TaskHierarchy, SingleTaskGraph
+from .task_graph import TaskGraph, TaskHierarchy
 from .utils import MultiYDataset, MultiXYDataset
 from .mt_classifier import MTClassifier
 from .mt_end_model import MTEndModel

--- a/metal/multitask/mt_end_model.py
+++ b/metal/multitask/mt_end_model.py
@@ -9,7 +9,7 @@ from torch.utils.data import DataLoader
 from metal.end_model import EndModel
 from metal.end_model.em_defaults import em_default_config
 from metal.end_model.loss import SoftCrossEntropyLoss
-from metal.multitask import TaskHierarchy, MTClassifier
+from metal.multitask import TaskGraph, MTClassifier
 from metal.multitask import MultiYDataset, MultiXYDataset
 from metal.multitask.mt_em_defaults import mt_em_default_config
 from metal.modules import IdentityModule
@@ -44,7 +44,7 @@ class MTEndModel(MTClassifier, EndModel):
             if K is None:
                 raise ValueError("You must supply either a list of "
                     "cardinalities (K) or a TaskGraph.")
-            task_graph = TaskHierarchy(edges=[], cardinalities=K)
+            task_graph = TaskGraph(K)
         self.task_graph = task_graph
         self.K = self.task_graph.K  # Cardinalities by task
         self.t = self.task_graph.t  # Total number of tasks

--- a/metal/multitask/mt_label_model.py
+++ b/metal/multitask/mt_label_model.py
@@ -1,7 +1,8 @@
 import numpy as np
+from scipy.sparse import issparse
 
 from metal.label_model import LabelModel
-from metal.multitask import MTClassifier
+from metal.multitask import MTClassifier, TaskGraph
 from metal.utils import recursive_merge_dicts
 from metal.label_model.lm_defaults import lm_default_config
 
@@ -12,39 +13,54 @@ class MTLabelModel(MTClassifier, LabelModel):
             K: A t-length list of task cardinalities (overrided by task_graph
                 if task_graph is not None)
             task_graph: TaskGraph: A TaskGraph which defines a feasible set of
-                task label vectors; overrides K
+                task label vectors; overrides K if provided
         """
         config = recursive_merge_dicts(lm_default_config, kwargs)
         MTClassifier.__init__(self, K, config)
 
-        # WARNING: Currently only storing 1 k for all tasks in self.k and
-        # ignoring self.K!
-        print("WARNING: Currently assuming all tasks have same cardinality!")
+        if task_graph is None:
+           task_graph = TaskGraph(K)
         self.task_graph = task_graph
-        if self.task_graph is None:
-            self.k = K  # TODO: this should not typecheck! scalar == list
-        else:
-            self.k = len(self.task_graph)
+
+        # Note: While K is a list of the cardinalities of the tasks, k is the 
+        # cardinality of the feasible set. These are always the same for a 
+        # single-task model, but rarely for a multi-task model.
+        self.K = self.task_graph.K  
+        self.k = self.task_graph.k
 
     def _set_constants(self, L):
         self.n, self.m = L[0].shape
         self.t = len(L)
 
-    def _create_L_ind(self, L, km, offset):
-        L_ind = np.ones((self.n, self.m * km))
+    def _create_L_ind(self, L):
+        """Convert T label matrices with labels in 0...K_t to a one-hot format
 
-        # TODO: By default, this will operate with offset = 1 by skipping
-        # abstains; should fix this!
+        An [n,m] matrix will become a [n,m*k] matrix. Note that no column is
+        required for 0 (abstain) labels.
+
+        Args:
+            L: a T-length list of [n,m] scipy.sparse label matrices with values
+                in {0,1,...,k}
+
+        Returns:
+            L_ind: An [n,m*k] dense np.ndarray with values in {0,1}
+        
+        Note that no column is required for 0 (abstain) labels.
+        """
+        # TODO: Update LabelModel to keep L, L_ind, L_aug as sparse matrices 
+        # throughout and remove this line.
+        if issparse(L[0]):
+            L = [L_t.todense() for L_t in L]
+
+        L_ind = np.ones((self.n, self.m * self.k))
         for yi, y in enumerate(self.task_graph.feasible_set()):
-            for s in range(self.t):
-                # Note that we cast to dense here, and are creating a dense
-                # matrix; can change to fully sparse operations if needed
-                L_s = L[s].todense()
-                L_ind[:, yi::km] *= np.where(
-                    np.logical_or(L_s == y[s], L_s == 0), 1, 0)
-            
-            # Handle abstains- if all elements of the task label are 0
-            L_ind[:, yi::km] *= np.where(
-                sum(map(abs, L)).todense() != 0, 1, 0)     
+            for t in range(self.t):
+                # A[x::y] slices A starting at x at intervals of y
+                # e.g., np.arange(9)[0::3] == np.array([0,3,6])
+                L_ind[:, yi::self.k] *= np.where(
+                    np.logical_or(L[t] == y[t], L[t] == 0), 1, 0)
+
+            # Set LFs that abstained on all feasible label vectors to all 0s
+            L_ind[:, yi::self.k] *= np.where(sum(L) != 0, 1, 0)     
 
         return L_ind   

--- a/metal/multitask/task_graph.py
+++ b/metal/multitask/task_graph.py
@@ -1,66 +1,46 @@
 from collections import defaultdict
+import itertools
 
 import numpy as np
 import networkx as nx
 
 
 class TaskGraph(object):
-    """A TaskGraph for t tasks is an object that defines a feasible subset of
-    all t-dimensional label vectors Y = [Y_1,...,Y_t].
-    A TaskGraph may also implement additional functionality which connects this
-    feasible set function to more interpretable semantics for the user.
-    """
-    def __init__(self):
-        pass
-    
-    def is_feasible(self, y):
-        return False
-    
-    def feasible_set(self):
-        """Iterator over values in feasible set"""
-        pass
+    """A directed graph defining dependencies between tasks
 
-
-class TaskHierarchy(TaskGraph):
-    """A mutually-exclusive task hierarchy
+    In the MTLabelModel, the TaskGraph is used to define a feasible subset of 
+    all t-dimensional label vectors Y = [Y_1,...,Y_t]; for example, in a 
+    mutually exclusive hierarchy, an example cannot have multiple non-zero leaf
+    labels.
     
+    In the MTEndModel, the TaskGraph is optionally used for auto-compilation of
+    an MTL network that attaches task heads at appropriate levels and passes
+    relevant information between tasks.
+
     Args:
         edges: A list of (a,b) tuples meaning a is a parent of b in a tree.
         cardinalities: A t-length list of integers corresponding to the
             cardinalities of each task.
-        
-    Defaults to a single binary task.
+
+    Defaults to a signle binary task.
     """
-    def __init__(self, edges=[], cardinalities=[2]):
-        # Number of tasks
-        self.K = cardinalities  # Max cardinality
+    def __init__(self, cardinalities=[2], edges=[]):
+        self.K = cardinalities       # Max cardinality
         self.t = len(cardinalities)  # Total number of tasks
         self.edges = edges
         
-        # Create a task hierarchy
+        # Create the graph of tasks
         self.G = nx.DiGraph()
         self.G.add_nodes_from(range(self.t))
         self.G.add_edges_from(edges)
         
-        # Check that G is a tree
-        # if not nx.is_tree(self.G):
-        #     raise ValueError(f"G is not a tree with edges {edges}.")
-        
-        # Check that the cardinality matches the number of children
-        # Note: Here we assume that the task indices are topologically ordered!
-        # TODO: remove this assumption of topological ordering
-        # for s in range(self.t):
-        #     if len([r for r in self.G[s].keys() if r > s]) not in [0, self.k]:
-        #         raise ValueError("Mismatch between cardinality and tree width.")
-        
-        # Get the leaf nodes
-        # Note: by this definition, not all leaf nodes need be at the same level
+        # Pre-compute parents, children, and leaf nodes
         self.leaf_nodes = [i for i in self.G.nodes() if self.G.out_degree(i)==0]
         self.parents = {t: self.get_parent(t) for t in range(self.t)}
-        self.children = {t: self.get_children(t) for t in range(self.t)}
+        self.children = {t: self.get_children(t) for t in range(self.t)} 
 
-    def __len__(self):
-        return len(self.leaf_nodes) * max(self.K)
+        # Save the cardinality of the feasible set
+        self.k = len(list(self.feasible_set()))
 
     def __eq__(self, other):
         return self.edges == other.edges and self.K == other.K
@@ -70,6 +50,26 @@ class TaskHierarchy(TaskGraph):
 
     def get_children(self, node):
         return sorted(list(self.G.successors(node)))
+
+    def is_feasible(self, y):
+        """Boolean indicator if the given y vector is valid (default: True)"""
+        return True
+    
+    def feasible_set(self):
+        """Iterator over values in feasible set"""
+        for y in itertools.product(*[range(k) for k in self.K]):
+            yield y
+
+
+class TaskHierarchy(TaskGraph):
+    """A mutually-exclusive task hierarchy (a tree)"""
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        
+        # Check that G is a tree
+        if not nx.is_tree(self.G):
+            raise ValueError(f"G is not a tree with edges {self.edges}. "
+                "If a tree is not required, use the generic TaskGraph class.")
 
     def is_feasible(self, y):
         return (y in list(self.feasible_set()))
@@ -88,16 +88,3 @@ class TaskHierarchy(TaskGraph):
                     pi = list(self.G.predecessors(pi))[0]
                     y[pi] = list(self.G.successors(pi)).index(ci) + 1
                 yield y
-
-
-class SingleTaskGraph(TaskHierarchy):
-    """
-    A TaskGraph with a single task.
-    
-    For example, a flat binary classification task can be represented as a
-    SingleTaskTree with one node whose cardinality is 2.
-    """    
-    def __init__(self, k=2):
-        cardinalities = [k]
-        edges = []
-        super().__init__(edges, cardinalities)

--- a/synthetic/generate.py
+++ b/synthetic/generate.py
@@ -34,7 +34,7 @@ def logistic_fn(x):
 def choose_other_label(k, y):
     """Given a cardinality k and true label y, return random value in 
     {1,...,k} \ {y}."""
-    return random.choice(list(set(range(1, k+1)) - set([y])))
+    return choice(list(set(range(1, k+1)) - set([y])))
 
 def indpm(x, y):
     """Plus-minus indicator function"""
@@ -180,8 +180,8 @@ class HierarchicalMultiTaskTreeDepsGenerator(SingleTaskTreeDepsGenerator):
 
         # Convert label matrix to tree task graph
         self.task_graph = TaskHierarchy(
+            cardinalities=[2,2,2],
             edges=[(0,1), (0,2)],
-            cardinalities=[2,2,2]
         )
         L_mt = [np.zeros((self.n, self.m)) for _ in range(self.task_graph.t)]
         fs = list(self.task_graph.feasible_set())

--- a/tests/metal/multitask/test_mt_end_model.py
+++ b/tests/metal/multitask/test_mt_end_model.py
@@ -6,7 +6,7 @@ import torch
 import torch.nn as nn
 
 from metal.modules import IdentityModule
-from metal.multitask import MTEndModel, TaskHierarchy
+from metal.multitask import MTEndModel, TaskGraph, TaskHierarchy
 
 class EndModelTest(unittest.TestCase):
 
@@ -36,7 +36,7 @@ class EndModelTest(unittest.TestCase):
         """Attach all task heads to the top layer"""
         edges = []
         cards = [2,2]
-        tg = TaskHierarchy(edges, cards)
+        tg = TaskGraph(cards, edges)
         em = MTEndModel(
             task_graph=tg,
             seed=1,
@@ -56,7 +56,7 @@ class EndModelTest(unittest.TestCase):
         """Attach the task heads at user-specified layers"""
         edges = [(0,1)]
         cards = [2,2]
-        tg = TaskHierarchy(edges, cards)
+        tg = TaskHierarchy(cards, edges)
         em = MTEndModel(
             task_graph=tg,
             seed=1,
@@ -76,7 +76,7 @@ class EndModelTest(unittest.TestCase):
         """Accept a different representation for each task"""
         edges = []
         cards = [2,2]
-        tg = TaskHierarchy(edges, cards)
+        tg = TaskGraph(cards, edges)
         em = MTEndModel(
             task_graph=tg,
             seed=1,
@@ -100,7 +100,7 @@ class EndModelTest(unittest.TestCase):
         """Accept a different representation for each task"""
         edges = []
         cards = [2,2]
-        tg = TaskHierarchy(edges, cards)
+        tg = TaskGraph(cards, edges)
         em = MTEndModel(
             task_graph=tg,
             seed=1,

--- a/tests/metal/multitask/test_mt_label_model.py
+++ b/tests/metal/multitask/test_mt_label_model.py
@@ -1,0 +1,46 @@
+import sys
+import unittest
+
+import numpy as np
+
+from metal.multitask import MTLabelModel
+
+sys.path.append("../synthetic")
+from synthetic.generate import HierarchicalMultiTaskTreeDepsGenerator
+
+
+class MTLabelModelTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.n_iters = 1
+        cls.n = 10000
+        cls.m = 10
+        cls.k = 2
+    
+    def _test_label_model(self, data, test_acc=True):
+        label_model = MTLabelModel(task_graph=data.task_graph, verbose=False)
+        label_model.train(data.L, deps=data.E, class_balance=data.p,
+            n_epochs=1000, print_every=200)
+        
+        # Test parameter estimation error
+        c_probs_est = label_model.get_conditional_probs()
+        err = np.mean(np.abs(data.c_probs - c_probs_est))
+        self.assertLess(err, 0.025)
+
+        # Test label prediction accuracy
+        if test_acc:
+            Y_pred = label_model.predict_proba(data.L).argmax(axis=1) + 1
+            acc = np.where(data.Y == Y_pred, 1, 0).sum() / data.n
+            self.assertGreater(acc, 0.95)
+    
+    def test_multitask(self):
+        for seed in range(self.n_iters):
+            np.random.seed(seed)
+            data = HierarchicalMultiTaskTreeDepsGenerator(self.n, self.m,
+                edge_prob=0.0)
+            self._test_label_model(data, test_acc=False)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/metal/multitask/test_task_graph.py
+++ b/tests/metal/multitask/test_task_graph.py
@@ -1,50 +1,41 @@
 
 import unittest
 
-from metal.multitask.task_graph import TaskHierarchy, SingleTaskGraph
+from metal.multitask.task_graph import TaskGraph, TaskHierarchy
 
 class TaskGraphTest(unittest.TestCase):
-
-    def test_single_task(self):
-        tg = SingleTaskGraph(k=3)
-        self.assertTrue(tg == TaskHierarchy([], [3]))
-        # self.assertTrue(tg.depth == 0)
 
     def test_binary_tree(self):
         cardinalities = [2,2,2]
         edges = [(0,1), (0,2)]
-        tg = TaskHierarchy(edges, cardinalities)
+        tg = TaskGraph(cardinalities, edges)
         self.assertTrue(tg.parents[0] == [])
         self.assertTrue(tg.parents[1] == [0])
         self.assertTrue(tg.parents[2] == [0])
         self.assertTrue(tg.children[0] == [1,2])
         self.assertTrue(tg.children[1] == [])
         self.assertTrue(tg.children[2] == [])
-        # self.assertTrue(tg.depth == 1)
         
     def test_nonbinary_tree(self):
         cardinalities = [3,2,2,2]
         edges = [(0,1), (0,2), (0,3)]
-        tg = TaskHierarchy(edges, cardinalities)
+        tg = TaskGraph(cardinalities, edges)
         self.assertTrue(tg.parents[1] == [0])
         self.assertTrue(tg.children[0] == [1,2,3])
-        # self.assertTrue(tg.depth == 1)
 
     def test_binary_tree_depth3(self):
         cardinalities = [2,2,2,2,2,2,2]
         edges = [(0,1), (0,2), (1,3), (1,4), (2,5), (2,6)]
-        tg = TaskHierarchy(edges, cardinalities)
+        tg = TaskGraph(cardinalities, edges)
         self.assertTrue(tg.parents[1] == [0])
         self.assertTrue(tg.children[1] == [3, 4])
-        # self.assertTrue(tg.depth == 2)
 
     def test_unbalanced_tree(self):
         cardinalities = [2,2,2]
         edges = [(0,1), (1,2)]
-        tg = TaskHierarchy(edges, cardinalities)
+        tg = TaskGraph(cardinalities, edges)
         self.assertTrue(tg.parents[1] == [0])
         self.assertTrue(tg.children[1] == [2])
-        # self.assertTrue(tg.depth == 2)
 
         
 if __name__ == '__main__':


### PR DESCRIPTION
-Make non-hierarchical TaskGraph a complete class.
-Move L.todense() inside _create_L_ind and outside of for loop
-Remove unnecessary offset and km variables
-Reorder TaskGraph to accept cardinalities before edges
-Add more docstrings everywhere
-Clarify how self.k is set for MTLabelModel
-Separate single-task and multi-task LabelModel tests