### PR TITLE
Fix CDR perf

### DIFF
--- a/metal/label_model/label_model.py
+++ b/metal/label_model/label_model.py
@@ -24,6 +24,16 @@ class LabelModel(Classifier):
         config = recursive_merge_dicts(lm_default_config, kwargs)
         super().__init__(k, config)
 
+    def _check_L(self, L):
+        """Run some basic checks on L."""
+        # TODO: Take this out?
+        if issparse(L):
+            L = L.todense()
+
+        # Check for correct values, e.g. warning if in {-1,0,1}
+        if np.any(L < 0):
+            raise ValueError("L must have values in {0,1,...,k}.")
+
     def _create_L_ind(self, L):
         """Convert a label matrix with labels in 0...k to a one-hot format
 
@@ -350,6 +360,7 @@ class LabelModel(Classifier):
         self._set_class_balance(class_balance, Y_dev)
         self._set_constants(L_train)
         self._set_dependencies(deps)
+        self._check_L(L_train)
 
         # Whether to take the simple conditionally independent approach, or the
         # "inverse form" approach for handling dependencies

--- a/metal/label_model/label_model.py
+++ b/metal/label_model/label_model.py
@@ -168,12 +168,15 @@ class LabelModel(Classifier):
         and similarly for higher-order cliques.
         - Z is the inverse form version of \mu.
         """
+        train_config = self.config["train_config"]
         # Initialize mu so as to break basic reflective symmetry
         # TODO: Update for higher-order cliques!
         self.mu_init = torch.zeros(self.d, self.k)
         for i in range(self.m):
             for y in range(self.k):
-                self.mu_init[i * self.k + y, y] += np.random.random()
+                self.mu_init[i * self.k + y, y] += (
+                    train_config["mu_init"] * np.random.random()
+                )
         self.mu = nn.Parameter(self.mu_init.clone()).float()
 
         if self.inv_form:

--- a/metal/label_model/lm_defaults.py
+++ b/metal/label_model/lm_defaults.py
@@ -11,7 +11,7 @@ lm_default_config = {
         # Class balance initialization / prior
         "class_balance_init": None,  # (array) If None, assume uniform
         # Model params initialization / priors
-        "mu_init": 0.4,
+        "mu_init": 0.5,
         # Optimizer
         "optimizer_config": {
             "optimizer": "sgd",

--- a/metal/multitask/mt_label_model.py
+++ b/metal/multitask/mt_label_model.py
@@ -32,6 +32,17 @@ class MTLabelModel(MTClassifier, LabelModel):
         self.n, self.m = L[0].shape
         self.t = len(L)
 
+    def _check_L(self, L):
+        """Run some basic checks on L."""
+        # TODO: Take this out?
+        if issparse(L[0]):
+            L = [L_t.todense() for L_t in L]
+
+        # Check for correct values, e.g. warning if in {-1,0,1}
+        for L_t in L:
+            if np.any(L_t < 0):
+                raise ValueError("L must have values in {0,1,...,k}.")
+
     def _create_L_ind(self, L):
         """Convert T label matrices with labels in 0...K_t to a one-hot format
 


### PR DESCRIPTION
- More sensible `mu_init`
- Check to confirm values in `{0,1,...,k}`, (e.g. throw error if in `{-1,0,1}`)