### PR TITLE
Fix error buckets

### DIFF
--- a/metal/analysis.py
+++ b/metal/analysis.py
@@ -329,7 +329,7 @@ def error_buckets(gold, pred, X=None):
     buckets = defaultdict(list)
     gold = arraylike_to_numpy(gold)
     pred = arraylike_to_numpy(pred)
-    for i, (y, l) in enumerate(zip(gold, pred)):
+    for i, (y, l) in enumerate(zip(pred, gold)):
         buckets[y, l].append(X[i] if X is not None else i)
     return buckets
 

--- a/metal/modules/sparse_linear_module.py
+++ b/metal/modules/sparse_linear_module.py
@@ -16,7 +16,7 @@ class SparseLinearModule(nn.Module):
         self.reset_parameters()
 
     def reset_parameters(self):
-        stdv = 1. / math.sqrt(self.vocab_size)
+        stdv = 1.0 / math.sqrt(self.vocab_size)
         self.W.weight.data.uniform_(-stdv, stdv)
         self.b.data.uniform_(-stdv, stdv)
         if self.padding_idx is not None:

--- a/metal/multitask/mt_classifier.py
+++ b/metal/multitask/mt_classifier.py
@@ -1,4 +1,3 @@
-
 import numpy as np
 
 from metal.classifier import Classifier

--- a/tests/metal/end_model/test_loss.py
+++ b/tests/metal/end_model/test_loss.py
@@ -67,7 +67,11 @@ class LossTest(unittest.TestCase):
         Y = torch.tensor([1, 1, 2], dtype=torch.long)
         Y_s = hard_to_soft(Y, k=3)
         Y_ps = torch.tensor(
-            [[-100., 100., -100.], [-100., 100., -100.], [-100., 100., -100.]]
+            [
+                [-100.0, 100.0, -100.0],
+                [-100.0, 100.0, -100.0],
+                [-100.0, 100.0, -100.0],
+            ]
         )
         weight1 = torch.tensor([1, 2, 1], dtype=torch.float)
         weight2 = torch.tensor([10, 20, 10], dtype=torch.float)

--- a/tests/metal/multitask/test_mt_end_model.py
+++ b/tests/metal/multitask/test_mt_end_model.py
@@ -1,4 +1,3 @@
-
 import unittest
 
 import numpy as np

--- a/tests/metal/multitask/test_task_graph.py
+++ b/tests/metal/multitask/test_task_graph.py
@@ -1,4 +1,3 @@
-
 import unittest
 
 from metal.multitask.task_graph import TaskGraph

--- a/tests/metal/test_analysis.py
+++ b/tests/metal/test_analysis.py
@@ -4,6 +4,7 @@ import numpy as np
 import scipy.sparse as sparse
 
 from metal.analysis import (
+    error_buckets,
     label_conflict,
     label_coverage,
     label_overlap,
@@ -51,6 +52,15 @@ class AnalysisTest(unittest.TestCase):
         self.assertTrue(
             (lf_conflicts(self.L) == np.array([0.2, 0.4, 0.4])).all()
         )
+
+    def test_error_buckets(self):
+        gold = [1, 1, 2, 1, 2]
+        pred = [1, 2, 1, 1, 2]
+        e_buckets = error_buckets(gold, pred)
+        self.assertEqual(e_buckets[1, 1], [0, 3])
+        self.assertEqual(e_buckets[1, 2], [2])
+        self.assertEqual(e_buckets[2, 2], [4])
+        self.assertEqual(e_buckets[2, 1], [1])
 
 
 if __name__ == "__main__":

--- a/tests/metal/test_metrics.py
+++ b/tests/metal/test_metrics.py
@@ -39,7 +39,7 @@ class MetricsTest(unittest.TestCase):
 
     def test_array_conversion(self):
         gold = torch.Tensor([1, 1, 1, 2, 2])
-        pred = np.array([1., 1., 1., 2., 1.])
+        pred = np.array([1.0, 1.0, 1.0, 2.0, 1.0])
         score = accuracy_score(gold, pred)
         self.assertAlmostEqual(score, 0.8)
 


### PR DESCRIPTION
Fix function so that return value matches documentation, and added small unit test.

In the error_buckets function documentation, it says that you access the returned value as [i,j] where i is the prediction and j is the gold label. However, how it was implemented, i & j were flipped.