### PR TITLE
Don't display progress bar if verbose=False

### DIFF
--- a/metal/classifier.py
+++ b/metal/classifier.py
@@ -174,7 +174,10 @@ class Classifier(nn.Module):
             for batch_num, data in tqdm(
                 enumerate(train_loader),
                 total=len(train_loader),
-                disable=train_config["disable_prog_bar"],
+                disable=(
+                    train_config["disable_prog_bar"]
+                    or not self.config["verbose"]
+                ),
             ):
 
                 # Moving data to GPU


### PR DESCRIPTION
Running our unit tests, for example, causes the terminal to fill up with progress bars. I think if verbose=False, the progress bar should be turned off too. All of our unit tests already run with verbose=False, so that also clears them up. Easy one-liner fix.