### PR TITLE
MTLEndModel training: save model with best validation score on a specific task

### DIFF
--- a/metal/classifier.py
+++ b/metal/classifier.py
@@ -231,12 +231,15 @@ class Classifier(nn.Module):
 
             if evaluate_dev and (epoch % train_config["validation_freq"] == 0):
                 val_metric = train_config["validation_metric"]
+                validation_scoring_kwargs = train_config[
+                    "validation_scoring_kwargs"
+                ]
                 dev_score = self.score(
                     dev_loader,
                     metric=val_metric,
                     verbose=False,
                     print_confusion_matrix=False,
-                    t=train_config.get("validation_task"),
+                    **validation_scoring_kwargs,
                 )
 
                 if train_config["checkpoint"]:
@@ -474,7 +477,7 @@ class Classifier(nn.Module):
             Y_p: An n-dim np.ndarray of predictions in {1,...k}
             [Optionally: Y_s: An [n, k] np.ndarray of predicted probabilities]
         """
-        Y_s = self._to_numpy(self.predict_proba(X))
+        Y_s = self._to_numpy(self.predict_proba(X, **kwargs))
         Y_p = self._break_ties(Y_s, break_ties).astype(np.int)
         if return_probs:
             return Y_p, Y_s

--- a/metal/classifier.py
+++ b/metal/classifier.py
@@ -371,7 +371,6 @@ class Classifier(nn.Module):
         break_ties="random",
         verbose=True,
         print_confusion_matrix=True,
-        t=None,
         **kwargs,
     ):
         """Scores the predictive performance of the Classifier on all tasks
@@ -470,7 +469,7 @@ class Classifier(nn.Module):
             Y_p: An n-dim np.ndarray of predictions in {1,...k}
             [Optionally: Y_s: An [n, k] np.ndarray of predicted probabilities]
         """
-        Y_s = self._to_numpy(self.predict_proba(X, **kwargs))
+        Y_s = self._to_numpy(self.predict_proba(X))
         Y_p = self._break_ties(Y_s, break_ties).astype(np.int)
         if return_probs:
             return Y_p, Y_s

--- a/metal/classifier.py
+++ b/metal/classifier.py
@@ -232,6 +232,7 @@ class Classifier(nn.Module):
                     metric=val_metric,
                     verbose=False,
                     print_confusion_matrix=False,
+                    t=train_config.get("validation_task"),
                 )
 
                 if train_config["checkpoint"]:
@@ -370,6 +371,7 @@ class Classifier(nn.Module):
         break_ties="random",
         verbose=True,
         print_confusion_matrix=True,
+        t=None,
         **kwargs,
     ):
         """Scores the predictive performance of the Classifier on all tasks

--- a/metal/end_model/em_defaults.py
+++ b/metal/end_model/em_defaults.py
@@ -44,6 +44,7 @@ em_default_config = {
         "l2": 0.0,
         "validation_metric": "accuracy",
         "validation_freq": 1,
+        "validation_scoring_kwargs": {},
         # Evaluate dev for during training every this many epochs
         # Optimizer
         "optimizer_config": {

--- a/metal/multitask/mt_classifier.py
+++ b/metal/multitask/mt_classifier.py
@@ -44,11 +44,11 @@ class MTClassifier(Classifier):
         self,
         data,
         metric="accuracy",
+        t=None,
         reduce="mean",
         break_ties="random",
         verbose=True,
         print_confusion_matrix=False,
-        t=None,
         **kwargs,
     ):
         """Scores the predictive performance of the Classifier on all tasks
@@ -58,10 +58,12 @@ class MTClassifier(Classifier):
                 Y: A t-length list of [n] or [n, 1] np.ndarrays or
                    torch.Tensors of gold labels in {1,...,K_t}
             metric: The metric with which to score performance on each task
+            t: Specific task to score.
             reduce: How to reduce the scores of multiple tasks:
                  None : return a t-length list of scores
                 'mean': return the mean score across tasks
             break_ties: How to break ties when making predictions
+
         Returns:
             scores: A (float) score or a t-length list of such scores if
                 reduce=None

--- a/metal/multitask/mt_classifier.py
+++ b/metal/multitask/mt_classifier.py
@@ -63,7 +63,6 @@ class MTClassifier(Classifier):
                  None : return a t-length list of scores
                 'mean': return the mean score across tasks
             break_ties: How to break ties when making predictions
-
         Returns:
             scores: A (float) score or a t-length list of such scores if
                 reduce=None

--- a/metal/multitask/mt_classifier.py
+++ b/metal/multitask/mt_classifier.py
@@ -48,6 +48,7 @@ class MTClassifier(Classifier):
         break_ties="random",
         verbose=True,
         print_confusion_matrix=False,
+        t=None,
         **kwargs,
     ):
         """Scores the predictive performance of the Classifier on all tasks
@@ -74,6 +75,15 @@ class MTClassifier(Classifier):
         if len(metric_list) > 1:
             raise NotImplementedError("Multiple metrics for multi-task.")
         metric = metric_list[0]
+
+        # Return score for just one task if t is passed.
+        if t is not None:
+            score = metric_score(
+                Y[t], Y_p[t], metric, probs=Y_s[t], ignore_in_gold=[0]
+            )
+            if verbose:
+                print(f"{metric.capitalize()}: {score:.3f}")
+            return score
 
         task_scores = []
         for t, Y_tp in enumerate(Y_p):

--- a/metal/multitask/mt_classifier.py
+++ b/metal/multitask/mt_classifier.py
@@ -44,7 +44,7 @@ class MTClassifier(Classifier):
         self,
         data,
         metric="accuracy",
-        t=None,
+        validation_task=None,
         reduce="mean",
         break_ties="random",
         verbose=True,
@@ -58,7 +58,8 @@ class MTClassifier(Classifier):
                 Y: A t-length list of [n] or [n, 1] np.ndarrays or
                    torch.Tensors of gold labels in {1,...,K_t}
             metric: The metric with which to score performance on each task
-            t: Specific task to score.
+            validation_task:
+                int: returns score for specific task number.
             reduce: How to reduce the scores of multiple tasks:
                  None : return a t-length list of scores
                 'mean': return the mean score across tasks
@@ -78,9 +79,13 @@ class MTClassifier(Classifier):
         metric = metric_list[0]
 
         # Return score for task t only.
-        if t is not None:
+        if validation_task is not None:
             score = metric_score(
-                Y[t], Y_p[t], metric, probs=Y_s[t], ignore_in_gold=[0]
+                Y[validation_task],
+                Y_p[validation_task],
+                metric,
+                probs=Y_s[validation_task],
+                ignore_in_gold=[0],
             )
             if verbose:
                 print(f"{metric.capitalize()}: {score:.3f}")
@@ -162,7 +167,10 @@ class MTClassifier(Classifier):
         """
         Y = self._to_numpy(Y)
         Y_tp = self.predict_task(X, t=t, **kwargs)
-        score = metric_score(Y, Y_tp, metric, ignore_in_gold=[0], **kwargs)
+        probs = self.predict_proba(X)[t]
+        score = metric_score(
+            Y[t], Y_tp, metric, ignore_in_gold=[0], probs=probs, **kwargs
+        )
         if verbose:
             print(f"[t={t}] {metric.capitalize()}: {score:.3f}")
         return score
@@ -176,7 +184,7 @@ class MTClassifier(Classifier):
         Returns:
             An n-dim tensor of hard (int) predictions for the specified task
         """
-        Y_tp = self.predict_task_proba(X, **kwargs)
+        Y_tp = self.predict_task_proba(X, t=t, **kwargs)
         Y_tph = self._break_ties(Y_tp, break_ties)
         return Y_tph
 

--- a/metal/multitask/mt_classifier.py
+++ b/metal/multitask/mt_classifier.py
@@ -77,7 +77,7 @@ class MTClassifier(Classifier):
             raise NotImplementedError("Multiple metrics for multi-task.")
         metric = metric_list[0]
 
-        # Return score for just one task if t is passed.
+        # Return score for task t only.
         if t is not None:
             score = metric_score(
                 Y[t], Y_p[t], metric, probs=Y_s[t], ignore_in_gold=[0]

--- a/metal/multitask/mt_em_defaults.py
+++ b/metal/multitask/mt_em_defaults.py
@@ -6,4 +6,5 @@ mt_em_default_config = {
     #   [list]: specify explicitly the layer for each head
     "pass_predictions": False,
     # If True, pass output of parent tasks as additional input to children tasks
+    "train_config": {"validation_task": None},
 }

--- a/metal/multitask/mt_em_defaults.py
+++ b/metal/multitask/mt_em_defaults.py
@@ -6,5 +6,5 @@ mt_em_default_config = {
     #   [list]: specify explicitly the layer for each head
     "pass_predictions": False,
     # If True, pass output of parent tasks as additional input to children tasks
-    "train_config": {"validation_task": None},
+    "train_config": {"validation_scoring_kwargs": {"validation_task": None}},
 }

--- a/metal/multitask/mt_end_model.py
+++ b/metal/multitask/mt_end_model.py
@@ -319,4 +319,4 @@ class MTEndModel(MTClassifier, EndModel):
 
     def predict_task_proba(self, X, t):
         """Returns an n x k matrix of probabilities for each label of task t"""
-        return self.predict_tasks_proba(X)[t]
+        return self.predict_proba(X)[t]

--- a/tests/metal/multitask/test_mt_end_model.py
+++ b/tests/metal/multitask/test_mt_end_model.py
@@ -142,7 +142,6 @@ class MTEndModelTest(unittest.TestCase):
             dev_data=(self.Xs[1], self.Ys[1]),
             verbose=False,
             n_epochs=3,
-            validation_metric="roc-auc",
             validation_task=0,
         )
         tasks = [0, 1]
@@ -153,17 +152,28 @@ class MTEndModelTest(unittest.TestCase):
                 reduce=None,
                 verbose=False,
             )
-            task_specific_scores = [
+            task_specific_scores_score_method = [
                 em.score(
                     (self.Xs[2], self.Ys[2]),
                     metric=metric,
-                    t=task,
+                    validation_task=task,
                     verbose=False,
                 )
                 for task in tasks
             ]
+            task_specific_scores_score_task_method = [
+                em.score_task(
+                    self.Xs[2], self.Ys[2], t=task, metric=metric, verbose=False
+                )
+                for task in tasks
+            ]
+
             for i in range(len(tasks)):
-                self.assertEqual(all_scores[i], task_specific_scores[i])
+                self.assertEqual(
+                    all_scores[i],
+                    task_specific_scores_score_method[i],
+                    task_specific_scores_score_task_method[i],
+                )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Add a parameter "t" to the MTLEndModel score method so user can specify which task they would like to score.

Also added a "validation_task" param to the Classifier.train_model method, analogous to the existing "validation_metric" param. If "validation_task" is passed then the checkpoint will keep the model that scores the highest for that task's validation_metric. Otherwise it will work as before.

This shouldn't affect the single EndModel.