### PR TITLE
Adds deterministic seeding for EndModel, submodules; adds hyperparam search over submodules

### DIFF
--- a/metal/classifier.py
+++ b/metal/classifier.py
@@ -157,6 +157,9 @@ class Classifier(nn.Module):
         train_loader = self._create_data_loader(train_data)
         dev_loader = self._create_data_loader(dev_data)
 
+        # Set model to train mode
+        self.train()
+
         # Moving model to GPU
         if self.config["use_cuda"]:
             if self.config["verbose"]:
@@ -297,6 +300,9 @@ class Classifier(nn.Module):
         # Close log_writer if available
         if log_writer is not None:
             log_writer.close()
+
+        # Set model to eval mode
+        self.eval()
 
     def _create_dataset(self, *data):
         """Converts input data to the appropriate Dataset"""

--- a/metal/classifier.py
+++ b/metal/classifier.py
@@ -299,7 +299,7 @@ class Classifier(nn.Module):
             if evaluate_dev:
                 self.score(
                     dev_loader,
-                    metric=["accuracy"],
+                    metric=train_config["validation_metric"],
                     verbose=True,
                     print_confusion_matrix=True,
                 )

--- a/metal/modules/lstm_module.py
+++ b/metal/modules/lstm_module.py
@@ -20,7 +20,7 @@ class LSTMModule(nn.Module):
         verbose=True,
         seed=123,
         lstm_num_layers=1,
-        **lstm_kwargs,
+        **kwargs,
     ):
         """
         Args:
@@ -75,13 +75,13 @@ class LSTMModule(nn.Module):
                 print(f"Using lstm_reduction = '{lstm_reduction}'")
 
         # Create lstm core
+        # NOTE: We only pass explicitly-named kwargs here; can always add more!
         self.lstm = nn.LSTM(
             embed_size,
             hidden_size,
             num_layers=lstm_num_layers,
             batch_first=True,
             bidirectional=bidirectional,
-            **lstm_kwargs,
         )
         if lstm_reduction == "attention":
             att_size = hidden_size * (self.lstm.bidirectional + 1)

--- a/metal/tuners/hyperband_tuner.py
+++ b/metal/tuners/hyperband_tuner.py
@@ -161,6 +161,8 @@ class HyperbandTuner(ModelTuner):
         train_args=[],
         init_kwargs={},
         train_kwargs={},
+        module_args={},
+        module_kwargs={},
         max_search=None,
         shuffle=True,
         verbose=True,
@@ -219,10 +221,6 @@ class HyperbandTuner(ModelTuner):
 
                     cur_model_index = n_models_scored
 
-                    # Set seed
-                    if configuration.get("seed", None) is None:
-                        configuration["seed"] = self.seed + cur_model_index
-
                     # Set epochs of the configuration
                     configuration["n_epochs"] = r_i
 
@@ -235,6 +233,8 @@ class HyperbandTuner(ModelTuner):
                         train_args=train_args,
                         init_kwargs=init_kwargs,
                         train_kwargs=train_kwargs,
+                        module_args=module_args,
+                        module_kwargs=module_kwargs,
                         verbose=verbose,
                         **score_kwargs,
                     )

--- a/metal/tuners/random_tuner.py
+++ b/metal/tuners/random_tuner.py
@@ -19,6 +19,8 @@ class RandomSearchTuner(ModelTuner):
         train_args=[],
         init_kwargs={},
         train_kwargs={},
+        module_args={},
+        module_kwargs={},
         max_search=None,
         shuffle=True,
         verbose=True,
@@ -33,6 +35,8 @@ class RandomSearchTuner(ModelTuner):
             train_args: (list) positional args for training the model
             init_kwargs: (dict) keyword args for initializing the model
             train_kwargs: (dict) keyword args for training the model
+            module_args: (dict) Dictionary of lists of module args
+            module_kwargs: (dict) Dictionary of dictionaries of module kwargs
             max_search: see config_generator() documentation
             shuffle: see config_generator() documentation
 
@@ -52,10 +56,6 @@ class RandomSearchTuner(ModelTuner):
 
         # Commence search
         for i, config in enumerate(configs):
-            # Unless seeds are given explicitly, give each config a unique one
-            if config.get("seed", None) is None:
-                config["seed"] = self.seed + i
-
             score, model = self._test_model_config(
                 i,
                 config,
@@ -64,6 +64,8 @@ class RandomSearchTuner(ModelTuner):
                 train_args=train_args,
                 init_kwargs=init_kwargs,
                 train_kwargs=train_kwargs,
+                module_args=module_args,
+                module_kwargs=module_kwargs,
                 verbose=verbose,
                 **score_kwargs,
             )

--- a/metal/tuners/tuner.py
+++ b/metal/tuners/tuner.py
@@ -16,8 +16,9 @@ class ModelTuner(object):
     Args:
         model_class: (nn.Module class) The model class to train (uninitiated)
         module_classes: (dict) An optional dictionary of module classes
-        (uninitiated), with keys corresponding to their kwargs in model class,
-        e.g. "input_module" in EndModel.
+        (uninitiated), with keys corresponding to their kwargs in model class;
+        for example, with model_class=EndModel, could have:
+            module_classes = {"input_module": metal.modules.LSTMModule}
         log_dir: (str) The path to the base log directory, or defaults to
             current working directory.
         run_dir: (str) The name of the sub-directory, or defaults to the date,

--- a/metal/tuners/tuner.py
+++ b/metal/tuners/tuner.py
@@ -26,6 +26,7 @@ class ModelTuner(object):
             strftime("%H_%M_%S").
         log_writer_class: a metal.utils.LogWriter class for logging the full
             model search.
+        validation_metric: The metric to use in scoring and selecting models.
 
         Saves model search logs and tuner report to 'log_dir/run_dir/run_name/.'
     """
@@ -39,10 +40,12 @@ class ModelTuner(object):
         run_name=None,
         log_writer_class=None,
         seed=None,
+        validation_metric="accuracy",
     ):
         self.model_class = model_class
         self.module_classes = module_classes
         self.log_writer_class = log_writer_class
+        self.validation_metric = validation_metric
 
         # Set logging subdirectory + make sure exists
         self.init_date = strftime("%Y_%m_%d")
@@ -151,7 +154,12 @@ class ModelTuner(object):
             log_writer=log_writer,
         )
 
-        score = model.score(dev_data, verbose=verbose, **score_kwargs)
+        score = model.score(
+            dev_data,
+            metric=self.validation_metric,
+            verbose=verbose,
+            **score_kwargs,
+        )
 
         # If score better than best_score, save
         if score > self.best_score:

--- a/metal/tuners/tuner.py
+++ b/metal/tuners/tuner.py
@@ -108,6 +108,9 @@ class ModelTuner(object):
             train_kwargs, config, misses="insert"
         )
 
+        # Also make sure train kwargs includes validation metric
+        train_kwargs["validation_metric"] = self.validation_metric
+
         # Initialize modules if provided
         for module_name, module_class in self.module_classes.items():
 

--- a/metal/tuners/tuner.py
+++ b/metal/tuners/tuner.py
@@ -160,7 +160,7 @@ class ModelTuner(object):
         score = model.score(
             dev_data,
             metric=self.validation_metric,
-            verbose=verbose,
+            verbose=False,  # Score is already printed in train_model above
             **score_kwargs,
         )
 

--- a/tests/metal/end_model/test_end_model.py
+++ b/tests/metal/end_model/test_end_model.py
@@ -157,6 +157,35 @@ class EndModelTest(unittest.TestCase):
         for i, metric in enumerate(metrics):
             self.assertGreater(scores[i], 0.95)
 
+    def test_determinism(self):
+        """Test whether training and scoring is deterministic given seed"""
+        em = EndModel(
+            seed=123,
+            batchnorm=True,
+            dropout=0.1,
+            layer_out_dims=[2, 10, 2],
+            verbose=False,
+        )
+        Xs, Ys = self.single_problem
+        em.train_model((Xs[0], Ys[0]), dev_data=(Xs[1], Ys[1]), n_epochs=1)
+        score_1 = em.score((Xs[2], Ys[2]), verbose=False)
+
+        # Test scoring determinism
+        score_2 = em.score((Xs[2], Ys[2]), verbose=False)
+        self.assertEqual(score_1, score_2)
+
+        # Test training determinism
+        em_2 = EndModel(
+            seed=123,
+            batchnorm=True,
+            dropout=0.1,
+            layer_out_dims=[2, 10, 2],
+            verbose=False,
+        )
+        em_2.train_model((Xs[0], Ys[0]), dev_data=(Xs[1], Ys[1]), n_epochs=1)
+        score_3 = em_2.score((Xs[2], Ys[2]), verbose=False)
+        self.assertEqual(score_1, score_3)
+
     def test_logging(self):
         """Test the basic LogWriter class"""
         log_writer = LogWriter(run_dir="test_dir", run_name="test")

--- a/tests/metal/tuners/test_random_search_tuner.py
+++ b/tests/metal/tuners/test_random_search_tuner.py
@@ -129,30 +129,34 @@ class RandomSearchModelTunerTest(unittest.TestCase):
         hidden_size = 10
         vocab_size = MAX_INT + 2
 
-        # Initialize LSTM module here
-        # TODO: Note the issue is that we will need to re-init each time...
-        lstm_module = LSTMModule(
-            embed_size,
-            hidden_size,
-            vocab_size=vocab_size,
-            seed=123,
-            bidirectional=True,
-            verbose=False,
-            lstm_reduction="attention",
-        )
-
         # Set up RandomSearchTuner
-        tuner = RandomSearchTuner(EndModel, log_writer_class=LogWriter)
+        tuner = RandomSearchTuner(
+            EndModel,
+            module_classes={"input_module": LSTMModule},
+            log_writer_class=LogWriter,
+            seed=123,
+        )
 
         # EndModel init kwargs
         init_kwargs = {
             "seed": 123,
             "batchnorm": True,
             "k": MAX_INT,
-            "input_module": lstm_module,
             "layer_out_dims": [hidden_size * 2, MAX_INT],
             "input_batchnorm": True,
             "verbose": False,
+        }
+
+        # LSTMModule args & kwargs
+        module_args = {}
+        module_args["input_module"] = (embed_size, hidden_size)
+        module_kwargs = {}
+        module_kwargs["input_module"] = {
+            "vocab_size": vocab_size,
+            "seed": 123,
+            "bidirectional": True,
+            "verbose": False,
+            "lstm_reduction": "attention",
         }
 
         # Set up search space
@@ -166,6 +170,8 @@ class RandomSearchModelTunerTest(unittest.TestCase):
             init_kwargs=init_kwargs,
             train_args=[(Xs[0], Ys[0])],
             train_kwargs={"n_epochs": 2},
+            module_args=module_args,
+            module_kwargs=module_kwargs,
             verbose=False,
         )
 


### PR DESCRIPTION
Major changes:
- Adds tests to ensure that given a random seed, `EndModel` is deterministic, including with submodules, e.g. `LSTMModule` as input layer
- Adds support to `Tuner` classes to search over the submodule hyperparameters
- Sets seed in `LSTMModule` random embeddings initialization

Minor things to check:
- Gets rid of unnamed pass-through hyperparameters in `LSTMModule` (to `nn.LSTM`); this was prompted by making things work in the `Tuner`, but seems much cleaner? Can always just add more explicitly named pass-through kwargs...
- Gets rid of cycling through random seeds in `Tuner` class during model search. The `Tuner` already has a global seed, and the models have seeds, so this just seems unnecessary, unless I am missing something?  It seems natural to expect that if two configs in the search space have the same hyperparams, the models should output the same results.

Other todos:
- [x] Add option to use different `validation_metric` in `Tuner`
- [x] Fix handling of `model.eval` and `model.train`; default to the former, except for in `self._train_model`
- [x] Make sure correct validation metric passed through to dev checkpointer in `Tuner`
- [x] Stop the `Tuner` from double-printing scores when dev checkpointer on