### PR TITLE
LSTM Encoder

### DIFF
--- a/metal/modules/__init__.py
+++ b/metal/modules/__init__.py
@@ -1,10 +1,12 @@
 from .identity_module import IdentityModule
-from .lstm_module import LSTMModule, Encoder, EmbeddingsEncoder
+from .lstm_module import LSTMModule, Encoder, EmbeddingsEncoder, CNNEncoder
 from .sparse_linear_module import SparseLinearModule
 
 __all__ = [
     "IdentityModule",
     "LSTMModule",
     "Encoder",
-    "EmbeddingsEncoder" "SparseLinearModule",
+    "EmbeddingsEncoder",
+    "CNNEncoder",
+    "SparseLinearModule",
 ]

--- a/metal/modules/__init__.py
+++ b/metal/modules/__init__.py
@@ -1,5 +1,10 @@
 from .identity_module import IdentityModule
-from .lstm_module import LSTMModule
+from .lstm_module import LSTMModule, Encoder, EmbeddingsEncoder
 from .sparse_linear_module import SparseLinearModule
 
-__all__ = ["IdentityModule", "LSTMModule", "SparseLinearModule"]
+__all__ = [
+    "IdentityModule",
+    "LSTMModule",
+    "Encoder",
+    "EmbeddingsEncoder" "SparseLinearModule",
+]

--- a/metal/modules/lstm_module.py
+++ b/metal/modules/lstm_module.py
@@ -14,7 +14,7 @@ class Encoder(nn.Module):
         encoded_size: (int) Output feature dimension of the Encoder
     """
 
-    def __init__(self, encoded_size):
+    def __init__(self, encoded_size, verbose=True):
         super().__init__()
         self.encoded_size = encoded_size
 

--- a/metal/modules/lstm_module.py
+++ b/metal/modules/lstm_module.py
@@ -4,90 +4,77 @@ import torch.nn.functional as F
 import torch.nn.utils.rnn as rnn_utils
 
 
-class LSTMModule(nn.Module):
-    """An LSTM-based input module"""
+class Encoder(nn.Module):
+    """The Encoder implements the encode() method, which maps a batch of data to
+    encoded output of dimension [batch_size, max_seq_len, encoded_size]
 
+    Args:
+        encoded_size: (int) Output feature dimension of the Encoder
+    """
+
+    def __init__(self, encoded_size):
+        super().__init__()
+        self.encoded_size = encoded_size
+
+    def encode(self, X):
+        """
+        Args:
+            X: (torch.LongTensor) of shape [batch_size, max_seq_length,
+            encoded_size], with all-0s vectors as padding.
+        """
+        assert X.shape[-1] == self.encoded_size
+        return X.float()
+
+
+class EmbeddingsEncoder(Encoder):
     def __init__(
         self,
-        embed_size,
-        hidden_size,
+        encoded_size,
         vocab_size=None,
         embeddings=None,
-        lstm_reduction="max",
         freeze=False,
-        skip_embeddings=False,
-        bidirectional=True,
         verbose=True,
         seed=123,
-        lstm_num_layers=1,
         **kwargs,
     ):
         """
         Args:
-            embed_size: The (integer) size of the input at each time
-                step; usually this is the size of the embeddings
-            hidden_size: The size of the hidden layer in the LSTM
+            encoded_size: (in) Output feature dimension of the Encoder, and
+                input feature dimension of the LSTM
             vocab_size: The size of the vocabulary of the embeddings
                 If embeddings=None, this helps to set the size of the randomly
-                    initilialized embeddings
-                If embeddings!=None, this is used to double check that the
+                    initialized embeddings
+                If embeddings != None, this is used to double check that the
                     provided embeddings have the intended size
             embeddings: An optional embedding Tensor
-            lstm_reduction: One of ['mean', 'max', 'last', 'attention']
-                denoting what to return as the output of the LSTMLayer
             freeze: If False, allow the embeddings to be updated
-            skip_embeddings: If True, directly accept X without using embeddings
         """
-        super().__init__()
-        self.lstm_reduction = lstm_reduction
-        self.output_dim = hidden_size * 2 if bidirectional else hidden_size
+        super().__init__(encoded_size)
         self.verbose = verbose
-        self.skip_embeddings = skip_embeddings
 
-        if not self.skip_embeddings:
+        # Load provided embeddings or randomly initialize new ones
+        if embeddings is None:
 
-            # Load provided embeddings or randomly initialize new ones
-            if embeddings is None:
+            # Note: Need to set seed here for deterministic init
+            if seed is not None:
+                self._set_seed(seed)
+            self.embeddings = nn.Embedding(vocab_size, encoded_size)
+            if self.verbose:
+                print(f"Using randomly initialized embeddings.")
+        else:
+            self.embeddings = self._load_pretrained(embeddings)
+            if self.verbose:
+                print(f"Using pretrained embeddings.")
 
-                # Note: Need to set seed here for deterministic init
-                if seed is not None:
-                    self._set_seed(seed)
-                self.embeddings = nn.Embedding(vocab_size, embed_size)
-                if self.verbose:
-                    print(f"Using randomly initialized embeddings.")
-            else:
-                self.embeddings = self._load_pretrained(embeddings)
-                if self.verbose:
-                    print(f"Using pretrained embeddings.")
-
-            # Freeze or not
-            self.embeddings.weight.requires_grad = not freeze
+        # Freeze or not
+        self.embeddings.weight.requires_grad = not freeze
 
         if self.verbose:
-            if self.skip_embeddings:
-                print("Skipping embeddings and using direct input.")
-            else:
-                print(
-                    f"Embeddings shape = ({self.embeddings.num_embeddings}, "
-                    f"{self.embeddings.embedding_dim})"
-                )
-                print(f"The embeddings are {'' if freeze else 'NOT '}FROZEN")
-                print(f"Using lstm_reduction = '{lstm_reduction}'")
-
-        # Create lstm core
-        # NOTE: We only pass explicitly-named kwargs here; can always add more!
-        self.lstm = nn.LSTM(
-            embed_size,
-            hidden_size,
-            num_layers=lstm_num_layers,
-            batch_first=True,
-            bidirectional=bidirectional,
-        )
-        if lstm_reduction == "attention":
-            att_size = hidden_size * (self.lstm.bidirectional + 1)
-            att_param = nn.Parameter(torch.FloatTensor(att_size, 1))
-            nn.init.xavier_normal_(att_param)
-            self.attention_param = att_param
+            print(
+                f"Embeddings shape = ({self.embeddings.num_embeddings}, "
+                f"{self.embeddings.embedding_dim})"
+            )
+            print(f"The embeddings are {'' if freeze else 'NOT '}FROZEN")
 
     def _set_seed(self, seed):
         self.seed = seed
@@ -102,13 +89,71 @@ class LSTMModule(nn.Module):
         if not pretrained.dim() == 2:
             msg = (
                 f"Provided embeddings have shape {pretrained.shape}. "
-                "Expected a 2-dimensional tesnor."
+                "Expected a 2-dimensional tensor."
             )
             raise ValueError(msg)
         rows, cols = pretrained.shape
         embedding = nn.Embedding(num_embeddings=rows, embedding_dim=cols)
         embedding.weight.data.copy_(pretrained)
         return embedding
+
+    def encode(self, X):
+        """
+        Args:
+            X: (torch.LongTensor) of shape [batch_size, max_seq_length],
+            containing the indices of the embeddings to look up for each item in
+            the batch, or 0 for padding.
+        """
+        return self.embeddings(X.long())
+
+
+class LSTMModule(nn.Module):
+    """An LSTM-based input module"""
+
+    def __init__(
+        self,
+        encoder,
+        hidden_size,
+        lstm_reduction="max",
+        bidirectional=True,
+        verbose=True,
+        seed=123,
+        lstm_num_layers=1,
+        **kwargs,
+    ):
+        """
+        Args:
+            encoder: An Encoder object with encode() method that maps from
+                input sequences to [batch_size, max_seq_len, feature_dim]
+            hidden_size: (int) The size of the hidden layer in the LSTM
+            lstm_reduction: One of ['mean', 'max', 'last', 'attention']
+                denoting what to return as the output of the LSTMLayer
+            freeze: If False, allow the embeddings to be updated
+            skip_embeddings: If True, directly accept X without using embeddings
+        """
+        super().__init__()
+        self.encoder = encoder
+        self.output_dim = hidden_size * 2 if bidirectional else hidden_size
+        self.verbose = verbose
+
+        self.lstm_reduction = lstm_reduction
+        if self.verbose:
+            print(f"Using lstm_reduction = '{lstm_reduction}'")
+
+        # Create lstm core
+        # NOTE: We only pass explicitly-named kwargs here; can always add more!
+        self.lstm = nn.LSTM(
+            self.encoder.encoded_size,
+            hidden_size,
+            num_layers=lstm_num_layers,
+            batch_first=True,
+            bidirectional=bidirectional,
+        )
+        if lstm_reduction == "attention":
+            att_size = hidden_size * (self.lstm.bidirectional + 1)
+            att_param = nn.Parameter(torch.FloatTensor(att_size, 1))
+            nn.init.xavier_normal_(att_param)
+            self.attention_param = att_param
 
     def _attention(self, output):
         # output is of shape (seq_length, hidden_size)
@@ -158,23 +203,8 @@ class LSTMModule(nn.Module):
         return torch.stack(reduced, dim=0)
 
     def forward(self, X):
-        """Applies one step of an lstm (plus reduction) to the input X
-
-        Args:
-            X: (torch.LongTensor) of shape [batch_size, max_seq_length],
-            containing the indices of the embeddings to look up for each item in
-            the batch, or 0 for padding; OR, if self.skip_embeddings == True and
-            features are directly being passed in, then has shape [batch_size,
-            max_seq_length, feat_dim], with all-0s vectors as padding.
-        """
-        # Check that X has the correct format
-        if len(X.shape) == 2 and not self.skip_embeddings:
-            X = X.long()
-        elif len(X.shape) == 3 and self.skip_embeddings:
-            X = X.float()
-        else:
-            raise ValueError(f"X {X.shape} and skip_embeddings do not match.")
-
+        """Applies one step of an lstm (plus reduction) to the input X, which
+        is handled by self.encoder"""
         # Identify the first non-zero integer from the right (i.e., the length
         # of the sequence before padding starts).
         batch_size, max_seq = X.shape[0], X.shape[1]
@@ -184,6 +214,7 @@ class LSTMModule(nn.Module):
                 if not torch.all(X[i, j] == 0):
                     seq_lengths[i] = j + 1
                     break
+
         # Sort by length because pack_padded_sequence requires it
         # Save original order to restore before returning
         seq_lengths, perm_idx = seq_lengths.sort(0, descending=True)
@@ -193,13 +224,15 @@ class LSTMModule(nn.Module):
             dtype=torch.long,
         )
 
-        X_encoded = X if self.skip_embeddings else self.embeddings(X)
+        # Encode and pack input sequence
         X_packed = rnn_utils.pack_padded_sequence(
-            X_encoded, seq_lengths, batch_first=True
+            self.encoder.encode(X), seq_lengths, batch_first=True
         )
 
+        # Run LSTM
         outputs, (h_t, c_t) = self.lstm(X_packed)
 
+        # Unpack and reduce outputs
         outputs_unpacked, _ = rnn_utils.pad_packed_sequence(
             outputs, batch_first=True
         )

--- a/metal/modules/lstm_module.py
+++ b/metal/modules/lstm_module.py
@@ -8,6 +8,8 @@ class Encoder(nn.Module):
     """The Encoder implements the encode() method, which maps a batch of data to
     encoded output of dimension [batch_size, max_seq_len, encoded_size]
 
+    The first argument must be the encoded size of the Encoder output.
+
     Args:
         encoded_size: (int) Output feature dimension of the Encoder
     """
@@ -112,13 +114,15 @@ class LSTMModule(nn.Module):
 
     def __init__(
         self,
-        encoder,
+        encoded_size,
         hidden_size,
         lstm_reduction="max",
         bidirectional=True,
         verbose=True,
         seed=123,
         lstm_num_layers=1,
+        encoder_class=Encoder,
+        encoder_kwargs={},
         **kwargs,
     ):
         """
@@ -132,9 +136,14 @@ class LSTMModule(nn.Module):
             skip_embeddings: If True, directly accept X without using embeddings
         """
         super().__init__()
-        self.encoder = encoder
         self.output_dim = hidden_size * 2 if bidirectional else hidden_size
         self.verbose = verbose
+
+        # Initialize Encoder
+        # Note constructing the Encoder here is helpful for e.g. Tuner, as then
+        # all model params initialized here
+        encoder_kwargs["verbose"] = self.verbose
+        self.encoder = encoder_class(encoded_size, **encoder_kwargs)
 
         self.lstm_reduction = lstm_reduction
         if self.verbose:

--- a/metal/modules/lstm_module.py
+++ b/metal/modules/lstm_module.py
@@ -109,6 +109,16 @@ class EmbeddingsEncoder(Encoder):
         return self.embeddings(X.long())
 
 
+class CNNEncoder(nn.Module):
+    def encode(self, X):
+        """
+        Args:
+            X: (torch.LongTensor) of shape [batch_size, max_seq_length,
+            encoded_size], with all-0s vectors as padding.
+        """
+        raise NotImplementedError()
+
+
 class LSTMModule(nn.Module):
     """An LSTM-based input module"""
 

--- a/tests/metal/modules/test_lstm.py
+++ b/tests/metal/modules/test_lstm.py
@@ -4,7 +4,7 @@ import numpy as np
 import torch
 
 from metal.end_model import EndModel
-from metal.modules import LSTMModule
+from metal.modules import EmbeddingsEncoder, Encoder, LSTMModule
 
 n = 1000
 SEQ_LEN = 5
@@ -31,12 +31,13 @@ class LSTMTest(unittest.TestCase):
 
         embed_size = 4
         hidden_size = 10
-        vocab_size = MAX_INT + 1
 
+        encoder = EmbeddingsEncoder(
+            embed_size, vocab_size=MAX_INT + 1, verbose=False
+        )
         lstm_module = LSTMModule(
-            embed_size,
+            encoder,
             hidden_size,
-            vocab_size=vocab_size,
             bidirectional=False,
             verbose=False,
             lstm_reduction="attention",
@@ -68,12 +69,13 @@ class LSTMTest(unittest.TestCase):
 
         embed_size = 4
         hidden_size = 10
-        vocab_size = MAX_INT + 2
 
+        encoder = EmbeddingsEncoder(
+            embed_size, vocab_size=MAX_INT + 2, verbose=False
+        )
         lstm_module = LSTMModule(
-            embed_size,
+            encoder,
             hidden_size,
-            vocab_size=vocab_size,
             bidirectional=True,
             verbose=False,
             lstm_reduction="attention",
@@ -106,16 +108,15 @@ class LSTMTest(unittest.TestCase):
 
         embed_size = 4
         hidden_size = 10
-        vocab_size = MAX_INT + 2
 
         for freeze_embs in [True, False]:
-            lstm_module = LSTMModule(
+            encoder = EmbeddingsEncoder(
                 embed_size,
-                hidden_size,
-                vocab_size=vocab_size,
+                vocab_size=MAX_INT + 2,
                 freeze=freeze_embs,
                 verbose=False,
             )
+            lstm_module = LSTMModule(encoder, hidden_size, verbose=False)
             em = EndModel(
                 k=MAX_INT,
                 input_module=lstm_module,
@@ -123,14 +124,14 @@ class LSTMTest(unittest.TestCase):
                 verbose=False,
             )
 
-            before = lstm_module.embeddings.weight.clone()
+            before = lstm_module.encoder.embeddings.weight.clone()
             em.train_model(
                 (Xs[0], Ys[0]),
                 dev_data=(Xs[1], Ys[1]),
                 n_epochs=15,
                 verbose=False,
             )
-            after = lstm_module.embeddings.weight.clone()
+            after = lstm_module.encoder.embeddings.weight.clone()
 
             if freeze_embs:
                 self.assertEqual(torch.abs(before - after).sum().item(), 0.0)
@@ -157,9 +158,8 @@ class LSTMTest(unittest.TestCase):
         hidden_size = 10
 
         lstm_module = LSTMModule(
-            embed_size,
+            Encoder(embed_size),
             hidden_size,
-            skip_embeddings=True,  # This is where we configure for this setting
             bidirectional=False,
             verbose=False,
             lstm_reduction="attention",
@@ -191,12 +191,13 @@ class LSTMTest(unittest.TestCase):
 
         embed_size = 4
         hidden_size = 10
-        vocab_size = MAX_INT + 2
 
+        encoder = EmbeddingsEncoder(
+            embed_size, vocab_size=MAX_INT + 2, verbose=False
+        )
         lstm_module = LSTMModule(
-            embed_size,
+            encoder,
             hidden_size,
-            vocab_size=vocab_size,
             seed=123,
             bidirectional=True,
             verbose=False,
@@ -220,10 +221,12 @@ class LSTMTest(unittest.TestCase):
         self.assertEqual(score_1, score_2)
 
         # Test training determinism
+        encoder_2 = EmbeddingsEncoder(
+            embed_size, vocab_size=MAX_INT + 2, verbose=False
+        )
         lstm_module_2 = LSTMModule(
-            embed_size,
+            encoder_2,
             hidden_size,
-            vocab_size=vocab_size,
             seed=123,
             bidirectional=True,
             verbose=False,

--- a/tests/metal/modules/test_lstm.py
+++ b/tests/metal/modules/test_lstm.py
@@ -32,15 +32,14 @@ class LSTMTest(unittest.TestCase):
         embed_size = 4
         hidden_size = 10
 
-        encoder = EmbeddingsEncoder(
-            embed_size, vocab_size=MAX_INT + 1, verbose=False
-        )
         lstm_module = LSTMModule(
-            encoder,
+            embed_size,
             hidden_size,
             bidirectional=False,
             verbose=False,
             lstm_reduction="attention",
+            encoder=EmbeddingsEncoder,
+            encoder_kwargs={"vocab_size": MAX_INT + 1},
         )
         em = EndModel(
             k=MAX_INT,
@@ -70,15 +69,14 @@ class LSTMTest(unittest.TestCase):
         embed_size = 4
         hidden_size = 10
 
-        encoder = EmbeddingsEncoder(
-            embed_size, vocab_size=MAX_INT + 2, verbose=False
-        )
         lstm_module = LSTMModule(
-            encoder,
+            embed_size,
             hidden_size,
             bidirectional=True,
             verbose=False,
             lstm_reduction="attention",
+            encoder=EmbeddingsEncoder,
+            encoder_kwargs={"vocab_size": MAX_INT + 2},
         )
         em = EndModel(
             k=MAX_INT,
@@ -110,13 +108,16 @@ class LSTMTest(unittest.TestCase):
         hidden_size = 10
 
         for freeze_embs in [True, False]:
-            encoder = EmbeddingsEncoder(
+            lstm_module = LSTMModule(
                 embed_size,
-                vocab_size=MAX_INT + 2,
-                freeze=freeze_embs,
+                hidden_size,
                 verbose=False,
+                encoder=EmbeddingsEncoder,
+                encoder_kwargs={
+                    "vocab_size": MAX_INT + 2,
+                    "freeze": freeze_embs,
+                },
             )
-            lstm_module = LSTMModule(encoder, hidden_size, verbose=False)
             em = EndModel(
                 k=MAX_INT,
                 input_module=lstm_module,
@@ -154,11 +155,11 @@ class LSTMTest(unittest.TestCase):
         Xs = self._split_dataset(X)
         Ys = self._split_dataset(Y)
 
-        embed_size = MAX_INT
+        encoded_size = MAX_INT
         hidden_size = 10
 
         lstm_module = LSTMModule(
-            Encoder(embed_size),
+            encoded_size,
             hidden_size,
             bidirectional=False,
             verbose=False,
@@ -192,16 +193,15 @@ class LSTMTest(unittest.TestCase):
         embed_size = 4
         hidden_size = 10
 
-        encoder = EmbeddingsEncoder(
-            embed_size, vocab_size=MAX_INT + 2, verbose=False
-        )
         lstm_module = LSTMModule(
-            encoder,
+            embed_size,
             hidden_size,
             seed=123,
             bidirectional=True,
             verbose=False,
             lstm_reduction="attention",
+            encoder=EmbeddingsEncoder,
+            encoder_kwargs={"vocab_size": MAX_INT + 2},
         )
         em = EndModel(
             k=MAX_INT,
@@ -221,16 +221,15 @@ class LSTMTest(unittest.TestCase):
         self.assertEqual(score_1, score_2)
 
         # Test training determinism
-        encoder_2 = EmbeddingsEncoder(
-            embed_size, vocab_size=MAX_INT + 2, verbose=False
-        )
         lstm_module_2 = LSTMModule(
-            encoder_2,
+            embed_size,
             hidden_size,
             seed=123,
             bidirectional=True,
             verbose=False,
             lstm_reduction="attention",
+            encoder=EmbeddingsEncoder,
+            encoder_kwargs={"vocab_size": MAX_INT + 2},
         )
         em_2 = EndModel(
             k=MAX_INT,

--- a/tests/metal/tuners/test_random_search_tuner.py
+++ b/tests/metal/tuners/test_random_search_tuner.py
@@ -147,17 +147,16 @@ class RandomSearchModelTunerTest(unittest.TestCase):
         }
 
         # LSTMModule args & kwargs
-        encoder = EmbeddingsEncoder(
-            embed_size, vocab_size=MAX_INT + 2, verbose=False
-        )
         module_args = {}
-        module_args["input_module"] = (encoder, hidden_size)
+        module_args["input_module"] = (embed_size, hidden_size)
         module_kwargs = {}
         module_kwargs["input_module"] = {
             "seed": 123,
             "bidirectional": True,
             "verbose": False,
             "lstm_reduction": "attention",
+            "encoder_class": EmbeddingsEncoder,
+            "encoder_kwargs": {"vocab_size": MAX_INT + 2},
         }
 
         # Set up search space

--- a/tests/metal/tuners/test_random_search_tuner.py
+++ b/tests/metal/tuners/test_random_search_tuner.py
@@ -6,7 +6,7 @@ import numpy as np
 import torch
 
 from metal.end_model import EndModel
-from metal.modules import LSTMModule
+from metal.modules import EmbeddingsEncoder, LSTMModule
 from metal.tuners.random_tuner import RandomSearchTuner
 from metal.utils import LogWriter
 
@@ -127,7 +127,6 @@ class RandomSearchModelTunerTest(unittest.TestCase):
 
         embed_size = 4
         hidden_size = 10
-        vocab_size = MAX_INT + 2
 
         # Set up RandomSearchTuner
         tuner = RandomSearchTuner(
@@ -148,11 +147,13 @@ class RandomSearchModelTunerTest(unittest.TestCase):
         }
 
         # LSTMModule args & kwargs
+        encoder = EmbeddingsEncoder(
+            embed_size, vocab_size=MAX_INT + 2, verbose=False
+        )
         module_args = {}
-        module_args["input_module"] = (embed_size, hidden_size)
+        module_args["input_module"] = (encoder, hidden_size)
         module_kwargs = {}
         module_kwargs["input_module"] = {
-            "vocab_size": vocab_size,
             "seed": 123,
             "bidirectional": True,
             "verbose": False,


### PR DESCRIPTION
Separates out the `Encoder` class more explicitly, making it easier to incorporate e.g. a CNN encoder for a CNN-LSTM

Changes the interface though so we should check it first