### PR TITLE
Fixes DataParallel activation caching bug in metal_model.forward

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -5,4 +5,4 @@ force_grid_wrap=0
 combine_as_imports=True
 line_length=88
 known_first_party=metal,synthetic,tests,tutorials
-known_third_party=GPUtil,boto3,dill,matplotlib,networkx,nltk,nose,numpy,pandas,paramiko,pytorch_pretrained_bert,scipy,setuptools,sklearn,spacy,tensorboardX,torch,torchtext,torchvision,tqdm
+known_third_party=GPUtil,IPython,apex,boto3,dill,matplotlib,networkx,nltk,nose,numpy,pandas,paramiko,pytorch_pretrained_bert,scipy,setuptools,sklearn,snorkel,spacy,tensorboardX,torch,torchtext,torchvision,tqdm

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -5,4 +5,4 @@ force_grid_wrap=0
 combine_as_imports=True
 line_length=88
 known_first_party=metal,synthetic,tests,tutorials
-known_third_party=GPUtil,IPython,apex,boto3,dill,matplotlib,networkx,nltk,nose,numpy,pandas,paramiko,pytorch_pretrained_bert,scipy,setuptools,sklearn,snorkel,spacy,tensorboardX,torch,torchtext,torchvision,tqdm
+known_third_party=GPUtil,boto3,dill,matplotlib,networkx,nltk,nose,numpy,pandas,paramiko,pytorch_pretrained_bert,scipy,setuptools,sklearn,spacy,tensorboardX,torch,torchtext,torchvision,tqdm

--- a/metal/mmtl/metal_model.py
+++ b/metal/mmtl/metal_model.py
@@ -103,19 +103,20 @@ class MetalModel(nn.Module):
         input = move_to_device(X, self.config["device"])
         outputs = {}
         for task_name in task_names:
-            input_module = self.input_modules[task_name]
+            # Extra .module because of DataParallel wrapper!
+            input_module = self.input_modules[task_name].module
             if input_module not in outputs:
                 outputs[input_module] = input_module(input)
-            middle_module = self.middle_modules[task_name]
+            middle_module = self.middle_modules[task_name].module
             if middle_module not in outputs:
                 outputs[middle_module] = middle_module(outputs[input_module])
-            attention_module = self.attention_modules[task_name]
+            attention_module = self.attention_modules[task_name].module
             if attention_module not in outputs:
                 outputs[attention_module] = attention_module(outputs[middle_module])
-            head_module = self.head_modules[task_name]
+            head_module = self.head_modules[task_name].module
             if head_module not in outputs:
                 outputs[head_module] = head_module(outputs[attention_module])
-        return {t: outputs[self.head_modules[t]] for t in task_names}
+        return {t: outputs[self.head_modules[t].module] for t in task_names}
 
     def calculate_loss(self, X, Ys, payload_name, labels_to_tasks):
         """Returns a dict of {task_name: loss (a FloatTensor scalar)}.


### PR DESCRIPTION
Current method has hash mismatch between same encoder wrapped by different DataParallel instances, which causes over-caching of redundant activations.  Simple fix.