### PR TITLE
Fix TypeError when using tensorboard log writer

### DIFF
--- a/metal/logging/writer.py
+++ b/metal/logging/writer.py
@@ -26,7 +26,13 @@ class LogWriter(object):
     """
 
     def __init__(
-        self, log_dir=None, run_dir=None, run_name=None, writer_metrics=[], verbose=True
+        self,
+        log_dir=None,
+        run_dir=None,
+        run_name=None,
+        writer_metrics=[],
+        verbose=True,
+        **kwargs,
     ):
         start_date = strftime("%Y_%m_%d")
         start_time = strftime("%H_%M_%S")


### PR DESCRIPTION
This PR is to solve an error when using the TensorBoard log writer. You can reproduce the error with the following code:

```python

In [1]: import torch
   ...: from metal.end_model import EndModel
   ...:
   ...: n_samples = 100
   ...: n_features = 10
   ...: n_classes = 2
   ...:
   ...: X = torch.rand((n_samples, n_features))
   ...: y = torch.rand((n_samples, n_classes))
   ...:
   ...: end_model = EndModel([n_features, 5, n_classes], writer="tensorboard", seed=123)
   ...: end_model.train_model((X, y), batch_size=5, n_epochs=5, checkpoint_metric='accuracy', checkpoint_metric_mode='max')

Network architecture:
Sequential(
  (0): IdentityModule()
  (1): Sequential(
    (0): Linear(in_features=10, out_features=5, bias=True)
    (1): ReLU()
  )
  (2): Linear(in_features=5, out_features=2, bias=True)
)

---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-1-545dacbd02d7> in <module>
     10
     11 end_model = EndModel([n_features, 5, n_classes], writer="tensorboard", seed=123)
---> 12 end_model.train_model((X, y), batch_size=5, n_epochs=5, checkpoint_metric='accuracy', checkpoint_metric_mode='max')

~/workspace/metal/metal/end_model/end_model.py in train_model(self, train_data, valid_data, log_writer, **kwargs)
    215         # Execute training procedure
    216         self._train_model(
--> 217             train_loader, loss_fn, valid_data=valid_data, log_writer=log_writer
    218         )
    219

~/workspace/metal/metal/classifier.py in _train_model(self, train_data, loss_fn, valid_data, log_writer, restore_state)
    198
    199         # Set training components
--> 200         self._set_writer(train_config)
    201         self._set_logger(train_config, epoch_size)
    202         self._set_checkpointer(train_config)

~/workspace/metal/metal/classifier.py in _set_writer(self, train_config)
    424             self.writer = LogWriter(**(train_config["writer_config"]))
    425         elif train_config["writer"] == "tensorboard":
--> 426             self.writer = TensorBoardWriter(**(train_config["writer_config"]))
    427         else:
    428             raise Exception(f"Unrecognized writer: {train_config['writer']}")

~/workspace/metal/metal/logging/tensorboard.py in __init__(self, log_dir, run_dir, run_name, **kwargs)
     16
     17     def __init__(self, log_dir=None, run_dir=None, run_name=None, **kwargs):
---> 18         super().__init__(log_dir=log_dir, run_dir=run_dir, run_name=run_name, **kwargs)
     19
     20         # Set up TensorBoard summary writer

TypeError: __init__() got an unexpected keyword argument 'include_config'
```

The change is just adding `**kwargs` to the init method of the `LogWriter` class. 

Please review. Thanks!